### PR TITLE
fix phpcs error, restrict buttons to non glossary page, apply standards

### DIFF
--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -184,14 +184,30 @@ class Glossary {
 							'nonce'              => wp_create_nonce( 'pb-glossary' ),
 							'glossary_title'     => __( 'Insert Glossary Term', 'pressbooks' ),
 							'glossary_all_title' => __( 'Insert Glossary List', 'pressbooks' ),
-							'glossary_terms'     => __( wp_json_encode( self::$glossary_terms ), 'pressbooks' ),
+							'glossary_terms'     => wp_json_encode( self::$glossary_terms ),
 						]
 					);
 				}
 			);
 
 			add_filter( 'mce_external_plugins', [ $this, 'addGlossaryPlugin' ] );
-			add_filter( 'mce_buttons_3', [ $this, 'registerGlossaryButtons' ] );
+
+			// to avoid 'inception' like glossary within a glossary, restricting
+			// glossary buttons means less chance of needing to untangle the labyrinth
+			global $typenow;
+
+			if ( empty( $typenow ) && ! empty( $_GET['post'] ) ) {
+				$post = get_post( $_GET['post'] );
+				$typenow = $post->post_type;
+			}
+			if ( 'glossary' !== $typenow ) {
+				add_filter(
+					'mce_buttons_3', [
+						$this,
+						'registerGlossaryButtons',
+					]
+				);
+			}
 		}
 
 	}

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -13,7 +13,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->gl = $this->getMockBuilder( '\Pressbooks\Shortcodes\Glossary\Glossary' )
-		                 ->setMethods( NULL )
+		                 ->setMethods( null )
 		                 ->disableOriginalConstructor()
 		                 ->getMock();
 


### PR DESCRIPTION
addresses https://github.com/BCcampus/pressbooks/issues/40 

- intent is to not display glossary buttons on glossary editing page. 
- phpcs error had to do with line 187 attempting to send an array into a translating function. 
![image](https://user-images.githubusercontent.com/2048170/43921383-71336180-9bd0-11e8-976c-81cfbfad7ba5.png)
